### PR TITLE
fix ratio for red belt

### DIFF
--- a/MaxRateCalculator/control.lua
+++ b/MaxRateCalculator/control.lua
@@ -13,7 +13,7 @@ g_marc_units = {}
 g_marc_units[1] = {name="marc-gui-persec", localized_name = {"marc-gui-persec"}, multiplier = 1, divisor = 1}
 g_marc_units[2] = {name="marc-gui-permin", localized_name = {"marc-gui-permin"}, multiplier = 60, divisor = 1}
 g_marc_units[3] = {name="marc-transport-belt", localized_name = {"marc-transport-belt"}, multiplier = 3, divisor = 40}
-g_marc_units[4] = {name="marc-fast-transport-belt", localized_name = {"marc-fast-transport-belt"}, multiplier = 2, divisor = 40}
+g_marc_units[4] = {name="marc-fast-transport-belt", localized_name = {"marc-fast-transport-belt"}, multiplier = 3, divisor = 80}
 g_marc_units[5] = {name="marc-express-transport-belt", localized_name = {"marc-express-transport-belt"}, multiplier = 1, divisor = 40}
 g_marc_units_count = 5
 


### PR DESCRIPTION
Fix as per https://mods.factorio.com/mods/Theanderblast/MaxRateCalculator/discussion/16453

divisor for belts should be 40/3 and multipliers 1/x instead of x
for yellow: `*1/(40/3)` which is equivalent to `*3/40` (so it's ok)
for red: `*(1/2)/(40/3)` which is equivalent to `*3/80`
for blue: `*(1/3)/(40/3)` which is equivalent to `*3/120` or `*1/40` (so it's ok)