### PR TITLE
add support for the rocket silo

### DIFF
--- a/MaxRateCalculator/control.lua
+++ b/MaxRateCalculator/control.lua
@@ -102,10 +102,10 @@ end
 local function get_entity_recipe(entity)
 	if entity.type == "furnace"
 	then
-		return (entity.get_recipe() or entity.previous_recipe)				
-	elseif entity.type == "assembling-machine"				
-	then 
-		return entity.get_recipe() 
+		return (entity.get_recipe() or entity.previous_recipe)
+	elseif entity.type == "assembling-machine" or entity.type == "rocket-silo"
+	then
+		return entity.get_recipe()
 	else
 		return nil
 	end
@@ -1037,7 +1037,7 @@ script.on_event(defines.events.on_player_selected_area,
 				debug_print("No energy")
 			end
 			
-			if entity.type == "assembling-machine" or entity.type == "furnace"
+			if entity.type == "assembling-machine" or entity.type == "furnace" or entity.type == "rocket-silo"
 			then		
 				if get_entity_recipe(entity)  ~= nil
 				then


### PR DESCRIPTION
The calc_assembler function works correctly for rocket silos, so this
is a very simple change. It might be nice in the future to customize
the display for the rocket silo to show rockets per minute, but that
would be rather more complicated.